### PR TITLE
When paused set paused condition and return

### DIFF
--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -52,7 +52,7 @@ import (
 	"github.com/open-cluster-management/backplane-operator/pkg/foundation"
 	"github.com/open-cluster-management/backplane-operator/pkg/hive"
 	renderer "github.com/open-cluster-management/backplane-operator/pkg/rendering"
-	status "github.com/open-cluster-management/backplane-operator/pkg/status"
+	"github.com/open-cluster-management/backplane-operator/pkg/status"
 
 	"github.com/open-cluster-management/backplane-operator/pkg/utils"
 )
@@ -118,7 +118,7 @@ func (r *MultiClusterEngineReconciler) Reconcile(ctx context.Context, req ctrl.R
 		log.Info("Updating status")
 		backplaneConfig.Status = r.StatusManager.ReportStatus(*backplaneConfig)
 		err := r.Client.Status().Update(ctx, backplaneConfig)
-		if backplaneConfig.Status.Phase != backplanev1alpha1.MultiClusterEnginePhaseAvailable {
+		if backplaneConfig.Status.Phase != backplanev1alpha1.MultiClusterEnginePhaseAvailable && !utils.IsPaused(backplaneConfig) {
 			retRes = ctrl.Result{RequeueAfter: 10 * time.Second}
 		}
 		if err != nil {
@@ -162,9 +162,9 @@ func (r *MultiClusterEngineReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	// Do not reconcile objects if this instance of mce is labeled "paused"
-	r.UpdatePausedCondition(backplaneConfig)
 	if utils.IsPaused(backplaneConfig) {
 		log.Info("MultiClusterEngine reconciliation is paused. Nothing more to do.")
+		r.StatusManager.AddCondition(status.NewCondition(backplanev1alpha1.MultiClusterEngineProgressing, metav1.ConditionUnknown, status.PausedReason, "Multiclusterengine is paused"))
 		return ctrl.Result{}, nil
 	}
 
@@ -387,24 +387,4 @@ func (r *MultiClusterEngineReconciler) ensureUnstructuredResource(ctx context.Co
 	}
 
 	return ctrl.Result{}, nil
-}
-
-func (r *MultiClusterEngineReconciler) UpdatePausedCondition(m *backplanev1alpha1.MultiClusterEngine) {
-	c := status.GetCondition(m.Status.Conditions, backplanev1alpha1.MultiClusterEngineProgressing)
-
-	if utils.IsPaused(m) {
-		// Pause condition needs to go on
-		if c == nil || c.Reason != status.PausedReason {
-			condition := status.NewCondition(backplanev1alpha1.MultiClusterEngineProgressing, metav1.ConditionUnknown, status.PausedReason, "Multiclusterengine is paused")
-			r.StatusManager.AddCondition(condition)
-		}
-	} else {
-		// Pause condition needs to come off
-		if c != nil && c.Reason == status.PausedReason {
-			condition := status.NewCondition(backplanev1alpha1.MultiClusterEngineProgressing, metav1.ConditionTrue, status.ResumedReason, "Multiclusterengine is resumed")
-			r.StatusManager.AddCondition(condition)
-
-		}
-
-	}
 }

--- a/pkg/status/condition.go
+++ b/pkg/status/condition.go
@@ -22,11 +22,8 @@ const (
 	DeleteTimestampReason = "DeletionTimestampPresent"
 	// WaitingForResourceReason means the reconciler is waiting on a resource before it can progress
 	WaitingForResourceReason = "WaitingForResource"
-
 	// PausedReason is added when the multiclusterengine is paused
 	PausedReason = "Paused"
-	// ResumedReason is added when the multiclusterengine is resumed
-	ResumedReason = "Resumed"
 )
 
 // NewCondition creates a new condition.
@@ -42,8 +39,8 @@ func NewCondition(condType bpv1alpha1.MultiClusterEngineConditionType, status me
 }
 
 // SetCondition sets the status condition. It either overwrites the existing one or creates a new one.
-func SetCondition(conditions []bpv1alpha1.MultiClusterEngineCondition, c bpv1alpha1.MultiClusterEngineCondition) []bpv1alpha1.MultiClusterEngineCondition {
-	currentCond := GetCondition(conditions, c.Type)
+func setCondition(conditions []bpv1alpha1.MultiClusterEngineCondition, c bpv1alpha1.MultiClusterEngineCondition) []bpv1alpha1.MultiClusterEngineCondition {
+	currentCond := getCondition(conditions, c.Type)
 	if currentCond != nil && currentCond.Status == c.Status && currentCond.Reason == c.Reason {
 		// Condition already present
 		return conditions
@@ -59,7 +56,7 @@ func SetCondition(conditions []bpv1alpha1.MultiClusterEngineCondition, c bpv1alp
 }
 
 // GetCondition returns the condition you're looking for by type
-func GetCondition(conditions []bpv1alpha1.MultiClusterEngineCondition, condType bpv1alpha1.MultiClusterEngineConditionType) *bpv1alpha1.MultiClusterEngineCondition {
+func getCondition(conditions []bpv1alpha1.MultiClusterEngineCondition, condType bpv1alpha1.MultiClusterEngineConditionType) *bpv1alpha1.MultiClusterEngineCondition {
 	for i := range conditions {
 		c := conditions[i]
 		if c.Type == condType {

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -27,7 +27,7 @@ func (sm *StatusTracker) AddComponent(sr StatusReporter) {
 }
 
 func (sm *StatusTracker) AddCondition(c bpv1alpha1.MultiClusterEngineCondition) {
-	sm.Conditions = SetCondition(sm.Conditions, c)
+	sm.Conditions = setCondition(sm.Conditions, c)
 }
 
 func (sm *StatusTracker) ReportStatus(mce bpv1alpha1.MultiClusterEngine) bpv1alpha1.MultiClusterEngineStatus {
@@ -64,7 +64,7 @@ func (sm *StatusTracker) reportConditions() []bpv1alpha1.MultiClusterEngineCondi
 }
 
 func (sm *StatusTracker) reportPhase(mce bpv1alpha1.MultiClusterEngine, components []bpv1alpha1.ComponentCondition, conditions []bpv1alpha1.MultiClusterEngineCondition) bpv1alpha1.PhaseType {
-	progress := GetCondition(conditions, bpv1alpha1.MultiClusterEngineProgressing)
+	progress := getCondition(conditions, bpv1alpha1.MultiClusterEngineProgressing)
 
 	// If operator isn't progressing show error phase
 	if progress != nil && progress.Status == metav1.ConditionFalse {

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -94,7 +94,7 @@ func Test_AddCondition(t *testing.T) {
 			t.Errorf("Expected two conditions. Got %v", len(cond))
 		}
 
-		c := GetCondition(cond, bpv1alpha1.MultiClusterEngineAvailable)
+		c := getCondition(cond, bpv1alpha1.MultiClusterEngineAvailable)
 		if c.Status != metav1.ConditionFalse {
 			t.Errorf("Condition was not updated. Expected %v to equal %v.", c.Status, metav1.ConditionFalse)
 		}


### PR DESCRIPTION
Simplify some of the status changes for when the operator is paused. Add check to not re-queue when paused, even if the mce is not fully available.

Signed-off-by: Jakob Gray <20209054+JakobGray@users.noreply.github.com>